### PR TITLE
Added link to Standard Unix Notes - a GPG encrypted notes/notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 
 - [Boostnote](https://github.com/BoostIO/Boostnote) - Intuitive and stylish note taking tool for developers. 👏
 - [Laverna](https://github.com/Laverna/laverna) - Keep your notes private. 👏
+- [notes](https://github.com/Standard-Unix-Notes/unix-notes) - GPG Encrypted Notes/Notebook manager for BSD/Linux👏
 - [Simplenote](https://github.com/Automattic/simplenote-electron) - Light, clean and free. 👏
 - [Tagspaces](https://github.com/tagspaces/tagspaces) - Offline, open source and data manager. 👏
 - [Turtl](https://github.com/turtl/desktop) - Secure and collaborative notebook. 👏


### PR DESCRIPTION
Hi

I've suggested Standard Unix Notes - a GPG encrypted ntoes/notebook manager that runs in any Unix/BSD/Linux etc that supports GnuPG.

It is written in the Bourne shell avoiding Bash as that is not installed by default on some machines.